### PR TITLE
Bump core version, changed the readme to advise on PHP minimum version

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 
 This package is a wrapper for our PHP library, which you can find here: <https://github.com/vonage/vonage-php-sdk-core>
 
+> Please note that all requirements for this package will match the core library, including platform requirements such
+> as a minimum requirement for PHP 7.4
+
 This package exists to separate the Vonage functionality from the HTTP Client. If you can't install this package due to a conflict with the `guzzle6-adapter` package, you can instead install:
 
 * The main package `vonage/client-core`

--- a/composer.json
+++ b/composer.json
@@ -16,15 +16,18 @@
     },
     {
       "name": "Michael Heap",
-      "role": "Developer"
+      "role": "Developer",
+      "homepage": "https://www.twitter.com/mheap"
     },
     {
       "name": "Lorna Mitchell",
-      "role": "Developer"
+      "role": "Developer",
+      "homepage": "https://lornajane.net/"
     },
     {
       "name": "Chris Tankersley",
-      "role": "Developer"
+      "role": "Developer",
+      "homepage": "https://twitter.com/dragonmantank"
     }
   ],
   "support": {

--- a/composer.json
+++ b/composer.json
@@ -5,33 +5,17 @@
   "type": "library",
   "authors": [
     {
-      "name": "Tim Lytle",
-      "email": "tim@nexmo.com",
-      "role": "Developer",
-      "homepage": "http://twitter.com/tjlytle"
-    },
-    {
-      "name": "Michael Heap",
-      "email": "michael.heap@vonage.com",
-      "role": "Developer"
-    },
-    {
-      "name": "Lorna Mitchell",
-      "email": "lorna.mitchell@vonage.com",
-      "role": "Developer"
-    },
-    {
-      "name": "Chris Tankersley",
-      "email": "chris.tankersley@vonage.com",
-      "role": "Developer"
+      "name": "James Seconde",
+      "email": "jim.seconde@vonage.com",
+      "role": "PHP Developer Advocate"
     }
   ],
   "support": {
-    "email": "devrel@nexmo.com"
+    "email": "devrel@vonage.com"
   },
   "require": {
-    "php": ">=7.2",
+    "php": "~7.4 || ~8.0 || ~8.1",
     "guzzlehttp/guzzle": "^7.0",
-    "vonage/client-core": "^2.0"
+    "vonage/client-core": "^3.0"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,23 @@
       "name": "James Seconde",
       "email": "jim.seconde@vonage.com",
       "role": "PHP Developer Advocate"
+    },
+    {
+      "name": "Tim Lytle",
+      "role": "Developer",
+      "homepage": "https://twitter.com/tjlytle"
+    },
+    {
+      "name": "Michael Heap",
+      "role": "Developer"
+    },
+    {
+      "name": "Lorna Mitchell",
+      "role": "Developer"
+    },
+    {
+      "name": "Chris Tankersley",
+      "role": "Developer"
     }
   ],
   "support": {


### PR DESCRIPTION
This PR bumps PHP versions to a minimum required of 7.4, plus targets the new Vonage PHP SDK core version of 3.0