### PR TITLE
Bump for version 4, php version requirements changed to reflect core

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 This package is a wrapper for our PHP library, which you can find here: <https://github.com/vonage/vonage-php-sdk-core>
 
 > Please note that all requirements for this package will match the core library, including platform requirements such
-> as a minimum requirement for PHP 7.4
+> as a minimum requirement for PHP 8.0
 
 This package exists to separate the Vonage functionality from the HTTP Client. If you can't install this package due to a conflict with the `guzzle6-adapter` package, you can instead install:
 

--- a/composer.json
+++ b/composer.json
@@ -34,8 +34,8 @@
     "email": "devrel@vonage.com"
   },
   "require": {
-    "php": "~7.4 || ~8.0 || ~8.1",
+    "php": "~8.0 || ~8.1 || ~8.2",
     "guzzlehttp/guzzle": "^7.0",
-    "vonage/client-core": "^3.0"
+    "vonage/client-core": "^4.0"
   }
 }


### PR DESCRIPTION
This PR bumps the connected core SDK import to the newly released version 4.